### PR TITLE
Adds support for AWS CLI profiles with hyphens

### DIFF
--- a/mfa.sh
+++ b/mfa.sh
@@ -31,16 +31,14 @@ if [[ $# -ne 1 && $# -ne 2 ]]; then
 fi
 
 echo "Reading config..."
-if [ -r ~/mfa.cfg ]; then
-  . ~/mfa.cfg
-else
+if [ ! -r ~/mfa.cfg ]; then
   echo "No config found.  Please create your mfa.cfg.  See README.txt for more info."
   exit 2
 fi
 
 AWS_CLI_PROFILE=${2:-default}
 MFA_TOKEN_CODE=$1
-ARN_OF_MFA=${!AWS_CLI_PROFILE}
+ARN_OF_MFA=$(grep "^$AWS_CLI_PROFILE" ~/mfa.cfg | cut -d '=' -f2- | tr -d '"')
 
 echo "AWS-CLI Profile: $AWS_CLI_PROFILE"
 echo "MFA ARN: $ARN_OF_MFA"


### PR DESCRIPTION
This fixes an issue where the MFA script would fail if any AWS profiles have a hyphen (`-`) in the name (e.g. `my-profile`).  The script was previously unable to extra the ARN from `mfa.cfg` for entries with a `-` in the name.  For example:

mfa.cfg:
```
default="arn:aws:iam::123456789:mfa/User.Name"
my-sandbox="arn:aws:iam::123456789:mfa/User.Name"
```

Example run on OS X prior to fix:
```
$ mfa 123456 my-sandbox
Using AWS CLI found at /usr/local/bin/aws
Reading config...
/Users/xxx/mfa.cfg: line 3: my-sandbox=arn:aws:iam::123456789:mfa/User.Name: No such file or directory
AWS-CLI Profile: my-sandbox
MFA ARN: 
MFA Token Code: 123456
Your Temporary Creds:
usage: aws [options] <command> <subcommand> [<subcommand> ...] [parameters]
To see help text, you can run:

  aws help
  aws <command> help
  aws <command> <subcommand> help
aws: error: argument --serial-number: expected one argument
Your creds have been set in your env.
```