### PR TITLE
Correctly set SCRIPT_PATH when using zsh

### DIFF
--- a/alias.sh
+++ b/alias.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
-SCRIPT_PATH="$( cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 ; pwd -P  )"
+SHELL_PROCESS=`ps -p $$ | sed -n 2p`
+if [[ "${SHELL_PROCESS}" == *"zsh"* ]]; then
+  RELEVANT_BASH_SOURCE="${(%):-%N}"
+else
+  RELEVANT_BASH_SOURCE="${BASH_SOURCE[0]}"
+fi
+SCRIPT_PATH="$( cd -- "$(dirname -- "${RELEVANT_BASH_SOURCE}")" >/dev/null 2>&1 ; pwd -P  )"
 setToken() {
     $SCRIPT_PATH/mfa.sh $1 $2
     source ~/.token_file


### PR DESCRIPTION
I use macOS with ["Oh My Zsh"](https://ohmyz.sh/) installed, so my terminal is `zsh`.

In `zsh`, the `BASH_SOURCE` environment variable is empty, and the way to get the same value you get in `bash` for `$BASH_SOURCE[0]` is `${(%):-%N}` [[Source](https://stackoverflow.com/a/23259585)].

I have adapted the `alias.sh` script so it detects if the shell is `zsh` and, if that's the case, it calculates the `SCRIPT_PATH` value taking this difference into account.

For `bash` shells, the script works as it did.